### PR TITLE
go tool vet no longer supported

### DIFF
--- a/run-go-vet.sh
+++ b/run-go-vet.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e -u -o pipefail # Fail on error
 for file in "$@"; do
-    go tool vet $file
+    go vet $file
 done


### PR DESCRIPTION
From the Go 1.12 release notes:
```
The go vet command has been rewritten to serve as the base for a range of different 
source code analysis tools. See thegolang.org/x/tools/go/analysis package for details. 
A side-effect is that go tool vet is no longer supported.External tools that use 
go tool vet must be changed to use go vet. Using go vet instead of go tool vet should 
work with all supported versions of Go.
```