### PR TITLE
Ensure we vet the entirety of the project

### DIFF
--- a/run-go-vet.sh
+++ b/run-go-vet.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 set -e -u -o pipefail # Fail on error
-for file in "$@"; do
-    go vet $file
-done
+
+gitroot=$(git rev-parse --show-toplevel)
+
+GOPATH=$GOPATH:$gitroot
+
+cd $gitroot
+
+go vet ./...


### PR DESCRIPTION
Rather than running go vet on a single file at a time, we are required
to run it on the entire project. This is because `go tool vet` and 
`go vet` differ in behavior. `go tool vet` is able to analyze and infer
types in a single file. `go vet` is unable to do so (and requires the
context of the entire project`. We change the behavior to run `go vet`
on the entire project.

More captured in this issue:
https://github.com/golang/go/issues/23916