### PR TITLE
Don't throw an error if GOPATH is unset

### DIFF
--- a/run-go-vet.sh
+++ b/run-go-vet.sh
@@ -3,7 +3,7 @@ set -e -u -o pipefail # Fail on error
 
 gitroot=$(git rev-parse --show-toplevel)
 
-GOPATH=$GOPATH:$gitroot
+GOPATH=${GOPATH:-}:$gitroot
 
 cd $gitroot
 


### PR DESCRIPTION
set -u makes bash blow up if a variable is unset when it's looked up. The
defaulting syntax, ${var:-default}, allows the variable to default to something
when it is unset. In this case, GOPATH defaults to blank if unset.


![Ahhhh… Stahp steamin' up my tail!](https://i.imgflip.com/d1ji7.gif)