### PR TITLE
Vetceleration: Don't run go vet on all packages always

### DIFF
--- a/run-go-vet.sh
+++ b/run-go-vet.sh
@@ -7,4 +7,7 @@ GOPATH=${GOPATH:-}:$gitroot
 
 cd $gitroot
 
-go vet ./...
+pkg=$(go list)
+for dir in $(echo $@|xargs -n1 dirname|sort -u); do
+  go vet $pkg/$dir
+done


### PR DESCRIPTION
Instead we run on all packages affected by the current commit.